### PR TITLE
Added try/catch to allow script to continue

### DIFF
--- a/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
+++ b/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
@@ -25,7 +25,7 @@ function Get-AuthToken {
 .SYNOPSIS
 This function is used to authenticate with the Graph API REST interface
 .DESCRIPTION
-The function authenticate with the Graph API Interface with the tenant name
+# The function authenticate with the Graph API Interface with the tenant name
 .EXAMPLE
 Get-AuthToken
 Authenticates you with the Graph API interface
@@ -448,6 +448,8 @@ $Devices = Get-Win10IntuneManagedDevice
 
 Foreach ($Device in $Devices){ 
 
+    try{
+
         Write-Host "Device name:" $device."deviceName" -ForegroundColor Cyan
         $IntuneDevicePrimaryUser = Get-IntuneDevicePrimaryUser -deviceId $Device.id
 
@@ -489,6 +491,13 @@ Foreach ($Device in $Devices){
                 Write-Host "The user '$($User.displayName)' is already the Primary User on the device..." -ForegroundColor Yellow
 
             }
+
+    }
+    Catch {
+
+        Write-Host "Could not set Primary User on Intune Managed Device" $Device."deviceName" ". Manual intervention may be required." -f Red 
+
+    }
 
     Write-Host
 

--- a/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
+++ b/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
@@ -445,6 +445,7 @@ else {
 
 #Get All Windows 10 Intune Managed Devices for the Tenant
 $Devices = Get-Win10IntuneManagedDevice
+$failedList = @()
 
 Foreach ($Device in $Devices){ 
 
@@ -487,6 +488,7 @@ Foreach ($Device in $Devices){
             }
 
             else {
+
                 #If the user is the same, then write to host that the primary user is already correct.
                 Write-Host "The user '$($User.displayName)' is already the Primary User on the device..." -ForegroundColor Yellow
 
@@ -494,11 +496,22 @@ Foreach ($Device in $Devices){
 
     }
     Catch {
-
+        # Warn on screen and log to a list which can be displayed as a final summary
         Write-Host "Could not set Primary User on Intune Managed Device" $Device."deviceName" ". Manual intervention may be required." -f Red 
+        $failedList += $Device."deviceName"
 
     }
 
     Write-Host
+
+}
+
+# If any devices failed, display a summary:
+if ($failedList.Count -ge 1) {
+
+    Write-Host "The following device(s) failed to have the Primary User set." -f Red
+    Foreach ($element in $failedList) {
+        Write-Host $element -f Red
+    }
 
 }

--- a/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
+++ b/PrimaryUser/Set-PrimaryUserfromLastLogIn.ps1
@@ -25,7 +25,7 @@ function Get-AuthToken {
 .SYNOPSIS
 This function is used to authenticate with the Graph API REST interface
 .DESCRIPTION
-# The function authenticate with the Graph API Interface with the tenant name
+The function authenticate with the Graph API Interface with the tenant name
 .EXAMPLE
 Get-AuthToken
 Authenticates you with the Graph API interface


### PR DESCRIPTION
As per issue #1, this allows the script to continue past a device that errors. It's a simple workaround using try/catch.

If this is ran against a large Intune deployment, there is a good chance some erroring devices won't be spotted so the name of any failed devices get added to an array which is displayed at the end.